### PR TITLE
Some changes for running Stainless on asn1jvm

### DIFF
--- a/asn1scala/src/main/scala/asn1scala/asn1jvm.scala
+++ b/asn1scala/src/main/scala/asn1scala/asn1jvm.scala
@@ -11,6 +11,7 @@ type UByte = Byte
 type UShort = Short
 type UInt = Int
 type ULong = Long
+@extern
 type RealNoRTL = Float
 type BooleanNoRTL = Boolean
 type ASCIIChar = UByte

--- a/asn1scala/src/main/scala/asn1scala/asn1jvm_encoding_uper.scala
+++ b/asn1scala/src/main/scala/asn1scala/asn1jvm_encoding_uper.scala
@@ -118,18 +118,18 @@ def ObjectIdentifier_uper_decode_lentg(pBitStrm: BitStream): Option[Long] = {
 
     return Some(totalSize)
 }
-def ObjectIdentifier_uper_decode(pBitStrm: BitStream): Option[Asn1ObjectIdentifier] = {
+def ObjectIdentifier_uper_decode(pBitStrm: BitStream): OptionMut[Asn1ObjectIdentifier] = {
     var si: ULong = 0
     var totalSize: Long = 0
-    var pVal = ObjectIdentifier_Init()
+    val pVal = ObjectIdentifier_Init()
 
     ObjectIdentifier_uper_decode_lentg(pBitStrm) match
-        case None() => return None()
+        case None() => return NoneMut()
         case Some(l) => totalSize = l
 
     ObjectIdentifier_subidentifiers_uper_decode(pBitStrm, totalSize) match
-        case None() => return None()
-        case Some(l, ul) =>
+        case None() => return NoneMut()
+        case Some((l, ul)) =>
             totalSize = l
             si = ul
 
@@ -140,8 +140,8 @@ def ObjectIdentifier_uper_decode(pBitStrm: BitStream): Option[Asn1ObjectIdentifi
         decreases(OBJECT_IDENTIFIER_MAX_LENGTH - pVal.nCount)
 
         ObjectIdentifier_subidentifiers_uper_decode(pBitStrm, totalSize) match
-            case None() => return None()
-            case Some(l, ul) =>
+            case None() => return NoneMut()
+            case Some((l, ul)) =>
                 totalSize = l
                 si = ul
 
@@ -150,25 +150,25 @@ def ObjectIdentifier_uper_decode(pBitStrm: BitStream): Option[Asn1ObjectIdentifi
 
     //return true, if totalSize reduced to zero. Otherwise we exit the loop because more components we present than OBJECT_IDENTIFIER_MAX_LENGTH
     if totalSize == 0 then
-        Some(pVal)
+        SomeMut(pVal)
     else
-        None()
+        NoneMut()
 
 }
-def RelativeOID_uper_decode (pBitStrm: BitStream): Option[Asn1ObjectIdentifier] = {
+def RelativeOID_uper_decode (pBitStrm: BitStream): OptionMut[Asn1ObjectIdentifier] = {
     var si: ULong = 0
     var totalSize: Long = 0
-    var pVal: Asn1ObjectIdentifier = ObjectIdentifier_Init()
+    val pVal: Asn1ObjectIdentifier = ObjectIdentifier_Init()
 
     ObjectIdentifier_uper_decode_lentg(pBitStrm) match
-        case None() => return None()
+        case None() => return NoneMut()
         case Some(l) => totalSize = l
 
     while totalSize > 0 && pVal.nCount < OBJECT_IDENTIFIER_MAX_LENGTH do
         decreases(OBJECT_IDENTIFIER_MAX_LENGTH - pVal.nCount)
         ObjectIdentifier_subidentifiers_uper_decode(pBitStrm, totalSize) match
-            case None() => return None()
-            case Some(l, ul) =>
+            case None() => return NoneMut()
+            case Some((l, ul)) =>
                 totalSize = l
                 si = ul
         pVal.values(pVal.nCount) = si
@@ -176,7 +176,7 @@ def RelativeOID_uper_decode (pBitStrm: BitStream): Option[Asn1ObjectIdentifier] 
 
     //return true, if totalSize is zero. Otherwise we exit the loop because more components were present than OBJECT_IDENTIFIER_MAX_LENGTH
     if totalSize == 0 then
-        Some(pVal)
+        SomeMut(pVal)
     else
-        None()
+        NoneMut()
 }

--- a/asn1scala/src/main/scala/asn1scala/stainless_utils.scala
+++ b/asn1scala/src/main/scala/asn1scala/stainless_utils.scala
@@ -19,6 +19,45 @@ val masksc: Array[Byte] = Array(
     -0x02,  //  / 1111 1110 /
 )
 
+def arrayRangesEqOffset[T](a1: Array[T], a2: Array[T], fromA1: Int, toA1: Int, fromA2: Int): Boolean = {
+    require(0 <= fromA1 && fromA1 <= toA1)
+    require(toA1 <= a1.length)
+    require(0 <= fromA2 && fromA2 <= a2.length - (toA1 - fromA1))
+    decreases(toA1 - fromA1)
+    if (fromA1 == toA1) true
+    else a1(fromA1) == a2(fromA2) && arrayRangesEqOffset(a1, a2, fromA1 + 1, toA1, fromA2 + 1)
+}
+
+def arrayCopyOffset[T](src: Array[T], dst: Array[T], fromSrc: Int, toSrc: Int, fromDst: Int): Unit = {
+    require(0 <= fromSrc && fromSrc <= toSrc)
+    require(toSrc <= src.length)
+    require(0 <= fromDst && fromDst <= dst.length - (toSrc - fromSrc))
+    decreases(toSrc - fromSrc)
+
+    if (fromSrc < toSrc) {
+        dst(fromDst) = src(fromSrc)
+        arrayCopyOffset(src, dst, fromSrc + 1, toSrc, fromDst + 1)
+    }
+}
+
+def arrayCopyOffsetLen[T](src: Array[T], dst: Array[T], fromSrc: Int, fromDst: Int, len: Int): Unit = {
+    require(0 <= len && len <= src.length && len <= dst.length)
+    require(0 <= fromSrc && fromSrc <= src.length - len)
+    require(0 <= fromDst && fromDst <= dst.length - len)
+    arrayCopyOffset(src, dst, fromSrc, fromSrc + len, fromDst)
+}
+
+def copyToArray[T](src: Array[T], dst: Array[T], startInDst: Int, len: Int): Unit = {
+    require(0 <= len && len <= src.length)
+    require(0 <= startInDst && startInDst <= src.length - len)
+    require(src.length <= dst.length)
+    arrayCopyOffset(src, dst, 0, len, startInDst)
+}
+
+def arraySameElements[T](a1: Array[T], a2: Array[T]): Boolean =
+    a1.length == a2.length && arrayRangesEqOffset(a1, a2, 0, a1.length, 0)
+
+// TODO: Reimplement in terms of arrayRangesEqOffset
 def arrayPrefix[T](a1: Array[T], a2: Array[T], from: Int, to: Int): Boolean = {
     require(0 <= from && from <= to)
     require(a1.length <= a2.length)


### PR DESCRIPTION
Note that the predicate used so far for comparing array elements (`arrayPrefix`) will be replaced by the more general `arrayRangesEqOffset` (for which lemmas still need to be adapted).