### PR TITLE
Add QoL Improvements

### DIFF
--- a/StgPython/acn_python.stg
+++ b/StgPython/acn_python.stg
@@ -19,6 +19,8 @@ class EncodeConstants:
     <arrsErrcodes; separator="\n">
     <sTypeDefName>_REQUIRED_BYTES_FOR_ACN_ENCODING = <nMaxBytesInACN>
     <sTypeDefName>_REQUIRED_BITS_FOR_ACN_ENCODING = <nMaxBitsInACN>
+    _REQUIRED_BYTES = <nMaxBytesInACN>
+    _CODEC = 'ACN'
 >>
 
 EmitTypeAssignment_primitive_encode(sVarName, sStar, sFuncName, soIValidFuncName, sTypeDefName, arrsLocalVariables, sContent, soSparkAnnotations, sInitialExp, arrsAcnPrms, arrsAcnParamNames, bEmptyEncodingSpace, bBsIsUnreferenced, bVarNameIsUnreferenced, bHasAcnChildrenToReturn, soInitFuncName, arrsAnnots, arrsPrecond, arrsPostcond) ::= <<
@@ -43,11 +45,10 @@ def <sFuncName>(self, codec: ACNEncoder, check_constraints: bool = True<if(arrsA
 >>
 
 EmitTypeAssignment_primitive_def_decode(sVarName, sStar, sFuncName, sTypeDefName, arrsErrcodes, bEmptyEncodingSpace, nMaxBytesInACN, nMaxBitsInACN, arrsAcnPrms, soSparkAnnotations) ::= <<
-<if(arrsErrcodes)>
 # acn_python.stg 55
 class DecodeConstants:
     <arrsErrcodes; separator="\n">
-<endif>
+    _CODEC = 'ACN'
 
 >>
 

--- a/StgPython/header_python.stg
+++ b/StgPython/header_python.stg
@@ -129,7 +129,7 @@ class <td.typeName>_Enum(IntEnum):
     __all__.append("<td.typeName>_Enum")
     <arrsEnumNamesAndValues:{it|<it>}; separator="\n">
 
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     # initialize val with the first enum element by default
@@ -150,7 +150,7 @@ Define_subType_enumerated_private(td/*:FE_EnumeratedTypeDefinition*/, prTd/*:FE_
 /***********************************       STRING    ************************************************************/
 
 Define_new_ia5string(td/*:FE_StringTypeDefinition*/, nMin, nMax, nCMax, arrnAlphaChars) ::= <<
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base): # header_python.stg 137
     __all__.append("<td.typeName>")
     arr: List[int]
@@ -170,7 +170,7 @@ Define_new_octet_string(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize
 
 <endif>
 
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
@@ -196,7 +196,7 @@ Define_new_bit_string(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize, 
 <arrsNamedBits:{it|<it>}; separator="\n">
 
 <if(!bFixedSize)># nCount equals to Number of bits in the array. Max value is : <nMax><endif>
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
@@ -207,7 +207,7 @@ class <td.typeName>(Asn1Base):
 
 Define_subType_bit_string(td/*:FE_SizeableTypeDefinition*/, prTd/*:FE_SizeableTypeDefinition*/, soParentTypePackage, nMin, nMax, bFixedSize) ::= <<
 # header_python.stg 194 - Define_subType_bit_string
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(<prTd.typeName>):
     __all__.append("<td.typeName>")
     
@@ -223,7 +223,7 @@ class <td.typeName>(<prTd.typeName>):
 Define_new_sequence_of(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize, sChildType, soChildDefinition, arrsSizeClassDefinition, arrsSizeObjDefinition, arrsInvariants) ::= <<
 # header_python.stg 201
 
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
@@ -270,14 +270,14 @@ Define_new_sequence(td/*:FE_SequenceTypeDefinition*/, arrsChildren, arrsOptional
 <arrsChildrenDefinitions; separator= "\n">
 <if (arrsNullFieldsSavePos)>
 
-@dataclass(frozen=True)
+@dataclass
 class <td.extension_function_positions>:
     __all__.append("<td.extension_function_positions>")
     <arrsNullFieldsSavePos; separator="\n">
     <arrsSizeDefinition; separator="\n\n">
 <endif>
 
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     <arrsChildren:{ch|<ch>}; separator="\n">
@@ -287,7 +287,7 @@ class <td.typeName>(Asn1Base):
 
 Define_subType_sequence(td/*:FE_SequenceTypeDefinition*/, prTd/*:FE_SequenceTypeDefinition*/, soParentTypePackage, arrsOptionalChildren, arrsExtraDefs) ::= <<
 # header_python.stg 268
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(<if(soParentTypePackage)><soParentTypePackage>.<endif><prTd.typeName>):
     __all__.append("<td.typeName>")
     <arrsExtraDefs; separator="\n">
@@ -313,7 +313,7 @@ class <td.typeName>InUse(IntEnum):
     __all__.append("<td.typeName>InUse")
     <arrsPresent:{ch|<ch> = <i0>}; separator="\n">
 
-@dataclass(frozen=True)
+@dataclass
 class <td.typeName>(Asn1Base):
     __all__.append("<td.typeName>")
     # which selection element is in use

--- a/StgPython/header_python.stg
+++ b/StgPython/header_python.stg
@@ -131,6 +131,7 @@ class <td.typeName>_Enum(IntEnum):
 
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 ENUMERATED type."""
     __all__.append("<td.typeName>")
     # initialize val with the first enum element by default
     val: <td.typeName>_Enum = <td.typeName>_Enum.<first(arrsEnumNames)>
@@ -152,6 +153,7 @@ Define_subType_enumerated_private(td/*:FE_EnumeratedTypeDefinition*/, prTd/*:FE_
 Define_new_ia5string(td/*:FE_StringTypeDefinition*/, nMin, nMax, nCMax, arrnAlphaChars) ::= <<
 @dataclass
 class <td.typeName>(Asn1Base): # header_python.stg 137
+    """ASN.1 IA5String type."""
     __all__.append("<td.typeName>")
     arr: List[int]
 >>
@@ -172,11 +174,31 @@ Define_new_octet_string(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize
 
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 OCTET STRING type."""
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
     arr: List[int] = field(default_factory=list)
-    
+
     <arrsInvariants; separator="\n">
+
+    def to_hex(self) -> str:
+        """Return hex string of the octet data."""
+        return ''.join(f'{b:02x}' for b in self.arr[:<if(!bFixedSize)>self.nCount<endif>])
+
+    @classmethod
+    def from_hex(cls, hex_str: str) -> '<td.typeName>':
+        """Create from hex string."""
+        data = bytes.fromhex(hex_str)
+        return cls(<if(!bFixedSize)>nCount=len(data), <endif>arr=list(data))
+
+    def as_bytes(self) -> bytes:
+        """Return the octet data as Python bytes."""
+        return bytes(self.arr[:<if(!bFixedSize)>self.nCount<endif>])
+
+    @classmethod
+    def from_raw_bytes(cls, data: bytes) -> '<td.typeName>':
+        """Create from Python bytes."""
+        return cls(<if(!bFixedSize)>nCount=len(data), <endif>arr=list(data))
 >>
 
 Define_subType_octet_string(td/*:FE_SizeableTypeDefinition*/, prTd/*:FE_SizeableTypeDefinition*/, soParentTypePackage, bFixedSize) ::= <<
@@ -198,11 +220,22 @@ Define_new_bit_string(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize, 
 <if(!bFixedSize)># nCount equals to Number of bits in the array. Max value is : <nMax><endif>
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 BIT STRING type."""
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
     arr: List[int] = field(default_factory=list)
-    
+
     <arrsInvariants; separator="\n">
+
+    def to_hex(self) -> str:
+        """Return hex string of the bit data (packed into bytes)."""
+        n_bytes = <if(!bFixedSize)>(self.nCount + 7) // 8<else>len(self.arr)<endif>
+        return ''.join(f'{b:02x}' for b in self.arr[:n_bytes])
+
+    def to_bin(self) -> str:
+        """Return binary string representation (one char per bit)."""
+        n_bits = <if(!bFixedSize)>self.nCount<else><nMax><endif>
+        return ''.join(f'{b:08b}' for b in self.arr)[:n_bits]
 >>
 
 Define_subType_bit_string(td/*:FE_SizeableTypeDefinition*/, prTd/*:FE_SizeableTypeDefinition*/, soParentTypePackage, nMin, nMax, bFixedSize) ::= <<
@@ -225,6 +258,7 @@ Define_new_sequence_of(td/*:FE_SizeableTypeDefinition*/, nMin, nMax, bFixedSize,
 
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 SEQUENCE OF type."""
     __all__.append("<td.typeName>")
     <if(!bFixedSize)>    nCount: int = 0<endif>
     arr: List[<sChildType>] = field(default_factory=list)
@@ -279,6 +313,7 @@ class <td.extension_function_positions>:
 
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 SEQUENCE type."""
     __all__.append("<td.typeName>")
     <arrsChildren:{ch|<ch>}; separator="\n">
     <arrsInvariants; separator="\n">
@@ -315,6 +350,7 @@ class <td.typeName>InUse(IntEnum):
 
 @dataclass
 class <td.typeName>(Asn1Base):
+    """ASN.1 CHOICE type."""
     __all__.append("<td.typeName>")
     # which selection element is in use
     kind: <td.typeName>InUse = <td.typeName>InUse.<first(arrsPresent)>

--- a/StgPython/uper_python.stg
+++ b/StgPython/uper_python.stg
@@ -45,6 +45,8 @@ class EncodeConstants:
     <arrsErrcodes:{x|<x>}; separator="\n">
     <sTypeDefName>_REQUIRED_BYTES_FOR_ENCODING: int = <nMaxBytesInPER>
     <sTypeDefName>_REQUIRED_BITS_FOR_ENCODING: int = <nMaxBitsInPER>
+    _REQUIRED_BYTES: int = <nMaxBytesInPER>
+    _CODEC: str = 'UPER'
 <endif>
 >>
 
@@ -66,11 +68,10 @@ def <sFuncName>(self, codec: UPEREncoder, check_constraints: bool = True) -> Non
 >>
 
 EmitTypeAssignment_def_decode(sVarName, sStar, sFuncName, sTypeDefName, arrsErrcodes, bEmptyEncodingSpace, nMaxBytesInPER, nMaxBitsInPER, soSparkAnnotations, bReqBytesForEncodingIsZero) ::= <<
-<if(arrsErrcodes)>
 # uper_python.stg 61
 class DecodeConstants:
     <arrsErrcodes:{x|<x>}; separator="\n">
-<endif>
+    _CODEC: str = 'UPER'
 
 >>
 

--- a/asn1python/src/asn1python/asn1_types.py
+++ b/asn1python/src/asn1python/asn1_types.py
@@ -5,8 +5,12 @@ This module provides sized integer types and ASN.1 semantic types
 that match the behavior of the C and Scala runtime libraries.
 """
 
+import dataclasses
+import json
+import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import IntEnum
 
 from .asn1_exceptions import *
 from .encoder import Encoder
@@ -32,6 +36,81 @@ class Asn1Base(ABC):
     @abstractmethod
     def is_constraint_valid(self) -> Asn1ConstraintValidResult:
         pass
+
+    def __str__(self) -> str:
+        if dataclasses.is_dataclass(self):
+            fields = dataclasses.fields(self)
+            if not fields:
+                return f"{type(self).__name__}()"
+            inner = "\n".join(f"  {f.name} = {getattr(self, f.name)}" for f in fields)
+            return f"{type(self).__name__}(\n{inner}\n)"
+        return repr(self)
+
+    def to_dict(self):
+        """Recursively convert this ASN.1 value to a plain Python dict."""
+        if dataclasses.is_dataclass(self):
+            return {f.name: _to_dict_val(getattr(self, f.name)) for f in dataclasses.fields(self)}
+        if isinstance(self, int):
+            return int(self)
+        if isinstance(self, float):
+            return float(self)
+        return repr(self)
+
+    @classmethod
+    def from_dict(cls, d):
+        """Reconstruct an instance from a plain Python dict (inverse of to_dict)."""
+        if not dataclasses.is_dataclass(cls):
+            return cls(d)
+        hints = typing.get_type_hints(cls)
+        kind_val = d.get('kind') if isinstance(d, dict) else None
+        kwargs = {}
+        for f in dataclasses.fields(cls):
+            if f.name not in d:
+                continue
+            hint = hints.get(f.name, type(None))
+            kv = kind_val if f.name == 'data' else None
+            kwargs[f.name] = _from_dict_val(d[f.name], hint, kv)
+        return cls(**kwargs)
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize this ASN.1 value to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, s: str):
+        """Deserialize an instance from a JSON string (inverse of to_json)."""
+        return cls.from_dict(json.loads(s))
+
+    def copy(self, **overrides):
+        """Return a shallow copy with optional field overrides."""
+        if dataclasses.is_dataclass(self):
+            return dataclasses.replace(self, **overrides)
+        return type(self)(overrides.get('value', self))
+
+    def to_bytes(self, check_constraints: bool = True) -> bytes:
+        """Encode this value to bytes using the type's default codec."""
+        ec = type(self).EncodeConstants
+        if ec._CODEC == 'UPER':
+            from .codec_uper import UPEREncoder
+            enc = UPEREncoder.of_size(ec._REQUIRED_BYTES)
+        else:
+            from .acn_encoder import ACNEncoder
+            enc = ACNEncoder.of_size(ec._REQUIRED_BYTES)
+        self.encode(enc, check_constraints)
+        encoded_bytes = (enc.bit_index + 7) // 8
+        return bytes(enc.get_bitstream_buffer()[:encoded_bytes])
+
+    @classmethod
+    def from_bytes(cls, data: bytes, check_constraints: bool = True):
+        """Decode an instance from bytes using the type's default codec."""
+        dc = cls.DecodeConstants
+        if dc._CODEC == 'UPER':
+            from .codec_uper import UPERDecoder
+            dec = UPERDecoder.from_buffer(bytearray(data))
+        else:
+            from .acn_decoder import ACNDecoder
+            dec = ACNDecoder.from_buffer(bytearray(data))
+        return cls.decode(dec, check_constraints)
 
 
 # Integer types using ctypes for automatic range validation and conversion
@@ -151,10 +230,78 @@ class NullType(Asn1Base):
     
     def encode(self, codec: Encoder, check_constraints: bool = True):
         return
-    
+
     @classmethod
     def decode(cls, codec: Decoder, check_constraints: bool = True):
         return NullType()
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers used by Asn1Base.to_dict / from_dict
+# ---------------------------------------------------------------------------
+
+def _to_dict_val(val):
+    """Convert a single field value to a dict-serializable form."""
+    if val is None:
+        return None
+    if isinstance(val, NullType):
+        return None
+    if isinstance(val, Asn1Boolean):
+        return bool(val)
+    if dataclasses.is_dataclass(val) and isinstance(val, Asn1Base):
+        return val.to_dict()
+    if isinstance(val, IntEnum):
+        return int(val)
+    if isinstance(val, list):
+        return [_to_dict_val(v) for v in val]
+    return val
+
+
+def _from_dict_val(val, hint, kind_val=None):
+    """Reconstruct a typed value from a dict-serializable value."""
+    origin = getattr(hint, '__origin__', None)
+    args = getattr(hint, '__args__', ())
+
+    if origin is typing.Union:
+        none_type = type(None)
+        has_python_none = none_type in args
+        non_none_args = [a for a in args if a is not none_type]
+        # Distinguish Optional[X] (Union[X, None]) from Choice data (Union[NullType, T1, T2, ...])
+        real_args = [a for a in non_none_args if not (isinstance(a, type) and issubclass(a, NullType))]
+
+        if val is None and has_python_none:
+            return None  # Optional sequence field is absent
+        if val is None:
+            return NullType()  # NullType ASN.1 value
+        if len(real_args) == 1:
+            return _from_dict_val(val, real_args[0])
+        if len(real_args) > 1 and kind_val is not None:
+            idx = int(kind_val)
+            if 0 <= idx < len(real_args):
+                return _from_dict_val(val, real_args[idx])
+        if non_none_args:
+            return _from_dict_val(val, non_none_args[0])
+        return val
+
+    if origin is list:
+        elem_type = args[0] if args else type(None)
+        return [_from_dict_val(v, elem_type) for v in (val or [])]
+
+    if hint is NullType or hint is type(None):
+        return NullType()
+
+    if isinstance(hint, type):
+        if issubclass(hint, Asn1Boolean):
+            return Asn1Boolean(val)
+        if issubclass(hint, Asn1Base) and isinstance(val, dict):
+            return hint.from_dict(val)
+        if issubclass(hint, IntEnum):
+            return hint(val)
+        if issubclass(hint, (int, float, str)):
+            return hint(val)
+
+    return val
+
 
 # Utility functions to match C and Scala implementations
 # def int2uint(v: int) -> int:


### PR DESCRIPTION
I made some QoL adjustments: 

- **Convenience encode/decode methods**

Currently users must manually manage codec objects:

    enc = UPEREncoder()
    packet.encode(enc)
    raw = enc.get_encoded_buffer()
    
    A to_bytes() / from_bytes() shorthand would eliminate this boilerplate:
    raw = packet.to_bytes()                      # UPER by default, or codec arg
    packet = TCCSDSPacket.from_bytes(raw)

- **to_dict() / from_dict() / to_json()**

Users almost always need to log, debug, or interop with JSON. Dataclasses don't auto-recurse for nested types, and asdict() only works if all values are dataclasses. A generated to_dict() that handles enums, byte arrays, and nested ASN.1 types would be very useful.

- **Docstrings with ASN.1 source**

Generated classes have no docstrings. Adding the original ASN.1 type definition as a docstring would make IDEs show it on hover — very useful when working with large schemas.

- **Octet/bit string helpers**

 OCTET STRING types are currently raw byte arrays. Helper methods like .to_hex(), .from_hex(), .to_bytes() would make them far easier to work with.

- **`__str__`**

Dataclass __repr__ is mechanical and not readable for deeply nested types. A __str__ that produces indented output (like pprint) would help debugging.