### PR TITLE
Revert stray STG-macro escape in ACN string charset encoder

### DIFF
--- a/asn1crt/asn1crt_encoding_acn.c
+++ b/asn1crt/asn1crt_encoding_acn.c
@@ -1243,7 +1243,7 @@ void Acn_Enc_String_CharIndex_FixSize(BitStream* pBitStrm, asn1SccSint max, byte
 {
 	asn1SccSint i = 0;
 	while (i<max) {
-		int charIndex = <GetCharIndex>(strVal[i], allowedCharSet, charSetSize);
+		int charIndex = GetCharIndex(strVal[i], allowedCharSet, charSetSize);
 		BitStream_EncodeConstraintWholeNumber(pBitStrm, charIndex, 0, charSetSize - 1);
 		i++;
 	}


### PR DESCRIPTION
Acn_Enc_String_CharIndex_FixSize called <GetCharIndex>(...) instead of GetCharIndex(...), so the embedded C runtime — copied into every generated C project — failed to compile.